### PR TITLE
Accept minimal M5 firmware frames in bridge protocol

### DIFF
--- a/src/lib/ws/m5-protocol.ts
+++ b/src/lib/ws/m5-protocol.ts
@@ -21,9 +21,12 @@ export interface M5BaseDeviceMessage {
 	type: M5DeviceMessageType;
 	deviceId: string;
 	role: M5DeviceRole;
-	seq: number;
-	timeMs: number;
-	quality: number;
+	// Optional: "minimal" firmware variants omit seq/timeMs/quality on some
+	// frame types. They are validated only when present. Orientation frames
+	// re-require `quality` (see M5OrientationMessage) because the bridge uses it.
+	seq?: number;
+	timeMs?: number;
+	quality?: number;
 }
 
 type M5BaseDeviceRecord = M5BaseDeviceMessage & Record<string, unknown>;
@@ -36,12 +39,15 @@ export interface M5RegisterMessage extends M5BaseDeviceMessage {
 
 export interface M5HeartbeatMessage extends M5BaseDeviceMessage {
 	type: "heartbeat";
-	rssi: number;
-	freeHeap: number;
-	batteryVoltage: number;
-	uptimeMs: number;
-	calibrated: boolean;
-	streaming: boolean;
+	// All telemetry fields are optional: "minimal" firmware variants send a
+	// reduced heartbeat (e.g. only rssi + uptimeMs). Heartbeats are status-only
+	// (the bridge does not act on them), so missing fields surface as null.
+	rssi?: number;
+	freeHeap?: number;
+	batteryVoltage?: number;
+	uptimeMs?: number;
+	calibrated?: boolean;
+	streaming?: boolean;
 }
 
 export interface M5ImuMessage extends M5BaseDeviceMessage {
@@ -54,7 +60,11 @@ export interface M5OrientationMessage extends M5BaseDeviceMessage {
 	type: "orientation";
 	pitch: number;
 	roll: number;
-	yaw: number;
+	// Required for orientation: the bridge drops low-quality frames using it.
+	quality: number;
+	// Optional: "minimal" firmware variants omit yaw. The bridge ignores it;
+	// it is only surfaced in the status panel (defaulted to 0 when absent).
+	yaw?: number;
 }
 
 export type M5DeviceMessage =
@@ -102,12 +112,12 @@ export function isM5HeartbeatMessage(
 ): data is M5HeartbeatMessage {
 	if (!hasM5BaseFields(data, "heartbeat")) return false;
 	return (
-		isFiniteNumber(data.rssi) &&
-		isFiniteNonNegativeNumber(data.freeHeap) &&
-		isFiniteNonNegativeNumber(data.batteryVoltage) &&
-		isFiniteNonNegativeNumber(data.uptimeMs) &&
-		typeof data.calibrated === "boolean" &&
-		typeof data.streaming === "boolean"
+		isOptional(data.rssi, isFiniteNumber) &&
+		isOptional(data.freeHeap, isFiniteNonNegativeNumber) &&
+		isOptional(data.batteryVoltage, isFiniteNonNegativeNumber) &&
+		isOptional(data.uptimeMs, isFiniteNonNegativeNumber) &&
+		isOptional(data.calibrated, isBoolean) &&
+		isOptional(data.streaming, isBoolean)
 	);
 }
 
@@ -123,7 +133,8 @@ export function isM5OrientationMessage(
 	return (
 		isFiniteNumber(data.pitch) &&
 		isFiniteNumber(data.roll) &&
-		isFiniteNumber(data.yaw)
+		isOptional(data.yaw, isFiniteNumber) &&
+		isNumberInRange(data.quality, M5_MIN_QUALITY, M5_MAX_QUALITY)
 	);
 }
 
@@ -136,10 +147,18 @@ function hasM5BaseFields(
 		data.type === type &&
 		isNonEmptyString(data.deviceId) &&
 		data.role === "controller" &&
-		isPositiveInteger(data.seq) &&
-		isFiniteNonNegativeNumber(data.timeMs) &&
-		isNumberInRange(data.quality, M5_MIN_QUALITY, M5_MAX_QUALITY)
+		isOptional(data.seq, isPositiveInteger) &&
+		isOptional(data.timeMs, isFiniteNonNegativeNumber) &&
+		isOptional(data.quality, isM5Quality)
 	);
+}
+
+function isM5Quality(data: unknown): data is number {
+	return isNumberInRange(data, M5_MIN_QUALITY, M5_MAX_QUALITY);
+}
+
+function isBoolean(data: unknown): data is boolean {
+	return typeof data === "boolean";
 }
 
 function isM5Vector3(data: unknown): data is M5Vector3 {
@@ -154,11 +173,68 @@ function isM5Vector3(data: unknown): data is M5Vector3 {
 function describeInvalidMessage(data: unknown): string {
 	if (!isRecord(data)) return "message must be a JSON object";
 	if (typeof data.type !== "string") return "type must be a string";
+
+	const baseReason = describeInvalidBaseFields(data);
+	if (baseReason) return baseReason;
+
+	if (data.type === "orientation") {
+		const fieldReason =
+			describeInvalidNumber(data, "pitch") ??
+			describeInvalidNumber(data, "roll") ??
+			describeInvalidOptionalNumber(data, "yaw");
+		if (fieldReason) return fieldReason;
+		if (!isM5Quality(data.quality))
+			return `quality must be a number between ${M5_MIN_QUALITY} and ${M5_MAX_QUALITY} (got ${describeValue(data.quality)})`;
+	}
+
 	return `unsupported shape for type "${data.type}"`;
+}
+
+function describeInvalidBaseFields(data: Record<string, unknown>): string | null {
+	if (!isNonEmptyString(data.deviceId))
+		return `deviceId must be a non-empty string (got ${describeValue(data.deviceId)})`;
+	if (data.role !== "controller")
+		return `role must be "controller" (got ${describeValue(data.role)})`;
+	if (!isOptional(data.seq, isPositiveInteger))
+		return `seq must be a positive integer > 0 when present (got ${describeValue(data.seq)})`;
+	if (!isOptional(data.timeMs, isFiniteNonNegativeNumber))
+		return `timeMs must be a non-negative number when present (got ${describeValue(data.timeMs)})`;
+	if (!isOptional(data.quality, isM5Quality))
+		return `quality must be a number between ${M5_MIN_QUALITY} and ${M5_MAX_QUALITY} when present (got ${describeValue(data.quality)})`;
+	return null;
+}
+
+function describeInvalidNumber(
+	data: Record<string, unknown>,
+	field: string,
+): string | null {
+	if (isFiniteNumber(data[field])) return null;
+	return `${field} must be a finite number (got ${describeValue(data[field])})`;
+}
+
+function describeInvalidOptionalNumber(
+	data: Record<string, unknown>,
+	field: string,
+): string | null {
+	if (isOptional(data[field], isFiniteNumber)) return null;
+	return `${field} must be a finite number when present (got ${describeValue(data[field])})`;
+}
+
+function describeValue(value: unknown): string {
+	if (typeof value === "string") return JSON.stringify(value);
+	if (value === undefined) return "undefined";
+	return String(value);
 }
 
 function isRecord(data: unknown): data is Record<string, unknown> {
 	return typeof data === "object" && data !== null;
+}
+
+function isOptional<T>(
+	data: unknown,
+	guard: (value: unknown) => value is T,
+): data is T | undefined {
+	return data === undefined || guard(data);
 }
 
 function isNonEmptyString(data: unknown): data is string {

--- a/src/lib/ws/m5-status.ts
+++ b/src/lib/ws/m5-status.ts
@@ -155,12 +155,12 @@ function recordHeartbeatMessage(message: M5HeartbeatMessage, now: number): void 
 	writeStatus({
 		...status,
 		lastHeartbeatAt: now,
-		rssi: message.rssi,
-		freeHeap: message.freeHeap,
-		batteryVoltage: message.batteryVoltage,
-		uptimeMs: message.uptimeMs,
-		calibrated: message.calibrated,
-		streaming: message.streaming,
+		rssi: message.rssi ?? null,
+		freeHeap: message.freeHeap ?? null,
+		batteryVoltage: message.batteryVoltage ?? null,
+		uptimeMs: message.uptimeMs ?? null,
+		calibrated: message.calibrated ?? null,
+		streaming: message.streaming ?? null,
 		updatedAt: now,
 	});
 }
@@ -176,7 +176,7 @@ function recordOrientationMessage(
 		orientation: {
 			pitch: message.pitch,
 			roll: message.roll,
-			yaw: message.yaw,
+			yaw: message.yaw ?? 0,
 			quality: message.quality,
 		},
 		updatedAt: now,

--- a/src/lib/ws/server-m5-bridge.ts
+++ b/src/lib/ws/server-m5-bridge.ts
@@ -68,8 +68,9 @@ export function startM5Bridge(
 		activeStates.add(state);
 
 		socket.on("message", (raw: RawData) => {
+			const rawText = rawDataToString(raw);
 			try {
-				const message = parseM5DeviceMessage(rawDataToString(raw));
+				const message = parseM5DeviceMessage(rawText);
 				recordM5DeviceMessage(message);
 				const state = rememberDevice(socket, message, clients);
 				latestDeviceId = message.deviceId;
@@ -77,7 +78,8 @@ export function startM5Bridge(
 			} catch (error) {
 				const message = getErrorMessage(error);
 				recordM5BridgeError(message);
-				console.warn("[m5-bridge] Invalid frame dropped", message);
+				console.warn("[m5-bridge] Invalid frame dropped:", message);
+				console.warn("[m5-bridge] Raw frame was:", truncateFrame(rawText));
 			}
 		});
 
@@ -367,4 +369,9 @@ function rawDataToString(raw: RawData): string {
 
 function getErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
+}
+
+function truncateFrame(text: string): string {
+	const MAX = 500;
+	return text.length > MAX ? `${text.slice(0, MAX)}… (${text.length} bytes)` : text;
 }


### PR DESCRIPTION
## Problem

Connecting an M5Stick running a **minimal firmware** variant (e.g. `0.2.1-icaros-minimal`) produced a flood of:

```
Invalid M5 message: unsupported shape for type "orientation"
```

The bridge validator (`src/lib/ws/m5-protocol.ts`) enforced the *full* device protocol, but the minimal firmware sends a reduced frame set. Diagnostics added during debugging showed the actual frames:

```json
// orientation — no seq, timeMs, yaw
{"type":"orientation","deviceId":"m5stick-plus2-001","role":"controller","pitch":-4.31,"roll":32.18,"quality":1}
// register — no seq, timeMs, quality
{"type":"register",...,"firmwareVersion":"0.2.1-icaros-minimal","capabilities":["imu","orientation"]}
// heartbeat — only rssi + uptimeMs
{"type":"heartbeat","deviceId":"...","role":"controller","rssi":-54,"uptimeMs":2756966,"quality":1}
```

`seq` failed validation first, surfacing as the generic "unsupported shape" error.

## Fix

The bridge only consumes `deviceId`, `role`, `pitch`, `roll`, and (for orientation) `quality`. The rest are telemetry/metadata. Make the unused fields **optional, still strictly validated when present**:

- `seq`, `timeMs`, `yaw` → optional
- `quality` → optional at the base, **still required for orientation** (the bridge uses it to drop low-quality input)
- heartbeat telemetry (`rssi`, `freeHeap`, `batteryVoltage`, `uptimeMs`, `calibrated`, `streaming`) → optional, surfaced as `null` in the status panel

Plus debugging quality-of-life:
- Per-field validation diagnostics — errors now name the exact field and value (`seq must be a positive integer > 0 when present (got 0)`) instead of "unsupported shape".
- The bridge logs the raw dropped frame, so future mismatches are immediately diagnosable.

Malformed frames are still rejected (string `pitch`, `quality:100`, `seq:0`, etc.).

## Verification

- `bunx biome check` clean on all three files.
- Parser unit-checked against minimal-firmware frames (pass), full spec frames (pass), and malformed frames (rejected with precise messages).
- Live test: real M5 hardware now registers and streams with **zero dropped frames**; `/vr` responds to tilt.

## Note

This relaxes the contract documented in `docs/M5_BRIDGE_PLAN.md`. The alternative was updating the external firmware (`M5_WebSocet_Adapter-main`) to emit full frames; the server-side fix unblocks the minimal firmware without touching the device. Happy to update the doc to note minimal-firmware support if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)